### PR TITLE
feat: Enhance ScreenSpaceRenderable with ordering and alignment controls

### DIFF
--- a/include/openspace/rendering/screenspacerenderable.h
+++ b/include/openspace/rendering/screenspacerenderable.h
@@ -39,6 +39,18 @@
 
 namespace ghoul::opengl { class ProgramObject; }
 
+enum class Alignment{
+    TopLeft,
+    TopCenter,
+    TopRight,
+    CenterLeft,
+    Center,
+    CenterRight,
+    BottomLeft,
+    BottomCenter,
+    BottomRight
+}
+
 namespace openspace {
 
 namespace documentation { struct Documentation; }
@@ -49,6 +61,9 @@ namespace documentation { struct Documentation; }
  * camera. It implements protected methods and properties for converting the planes from
  * Spherical to Cartesian coordinates and back. It also specifies the interface that its
  * children need to implement.
+ * Enhanced features:
+ * - RenderOrder: Controls draw order (lower values render first)
+ * - Alignment: 9-point alignment system (TopLeft, Center, etc.)
  */
 class ScreenSpaceRenderable : public properties::PropertyOwner, public Fadeable {
 public:
@@ -97,8 +112,30 @@ public:
 
     static documentation::Documentation Documentation();
 
+    constexpr properties::Property::PropertyInfo RenderOrderInfo = {
+        "RenderOrder",
+        "Render Order",
+        "Lower values render first (behind higher values)",
+        properties::Property::Visibility::User
+    };
+    
+    constexpr properties::Property::PropertyInfo AlignmentInfo = {
+        "Alignment",
+        "Alignment",
+        "Anchor point for positioning",
+        properties::Property::Visibility::User
+    }; 
+
 protected:
+    void setEnabled(bool isEnabled);
+    float depth();
+    float scale() const;
     void createShaders(ghoul::Dictionary dict = ghoul::Dictionary());
+    void setRenderOrder(float order);
+    float renderOrder() const;
+    void setAlignment(Alignment alignment);
+    Alignment alignment() const;
+
     std::string makeUniqueIdentifier(std::string name);
 
     virtual glm::mat4 scaleMatrix();
@@ -148,6 +185,9 @@ protected:
     properties::Vec3Property _multiplyColor;
     properties::Vec4Property _backgroundColor;
     properties::TriggerProperty _delete;
+
+    properties::FloatProperty _renderOrder;
+    properties::OptionProperty _alignment;
 
     glm::ivec2 _objectSize = glm::ivec2(0);
     UniformCache(color, opacity, blackoutFactor, hue, value, saturation, mvpMatrix, tex,


### PR DESCRIPTION
- Added render ordering support via new `RenderOrder` property (lower values render first)
- Implemented 9-point alignment system (TopLeft, Center, BottomRight, etc.)
- Removed deprecated RAE (Radius-Azimuth-Elevation) coordinate system
- Improved Cartesian positioning with normalized [0,1] screen coordinates
- Added new methods: `setRenderOrder()`, `renderOrder()`, `setAlignment()`, `alignment()`, `setScreenPosition()`
- Updated translation matrix to respect alignment points

Addresses Issue #2250